### PR TITLE
branch stond nog 'hard-coded' op refactor-test. Volgens de stackoverf…

### DIFF
--- a/.github/workflows/ping-integration.yaml
+++ b/.github/workflows/ping-integration.yaml
@@ -38,4 +38,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/xiffy/sbr.nl-web/actions/workflows/integration.yaml/dispatches \
-          -d '{"ref":"${{ github.ref }}", "inputs": {"branch": "refactor-test", "repository": "${{ github.repository }}", "taxonomy_name": "${{ env.TAX_NAME }}", "message": "it me" }}'
+          -d '{"ref":"${{ github.ref }}", "inputs": {"branch": "${{ github.ref_name}} ", "repository": "${{ github.repository }}", "taxonomy_name": "${{ env.TAX_NAME }}", "message": "it me" }}'


### PR DESCRIPTION
Volgens de stackoverflows geeft `github.ref_name` de branch of tag terug die de action triggerde.

(it did)